### PR TITLE
Vcs instance names

### DIFF
--- a/ec2host
+++ b/ec2host
@@ -18,7 +18,7 @@ sub describe_instances {
 
   # Assemble instance filters
   my @filters = ("Name=instance-state-name,Values=running");
-  push @filters, "Name=tag:$tag_name,Values=$tag_value" if $tag_value;
+  push @filters, "Name=tag:$tag_name,Values=" . qq("$tag_value") if $tag_value;
   push @filters, "$filters" if $filters;
 
   # Assemble describe-instance command

--- a/ec2ssh
+++ b/ec2ssh
@@ -36,7 +36,7 @@ else {
 }
 
 # Retrieve a list of ec2 instances matching provided criteria
-my $cmd= "ec2host $instance_name";
+my $cmd= "ec2host " . qq("$instance_name");
 $cmd.= " --filters $filters" if $filters;
 $cmd.= " --profile $profile" if $profile;
 $cmd.= " --region $region" if $region;

--- a/ec2ssh
+++ b/ec2ssh
@@ -62,7 +62,7 @@ else {
     : undef;
   if($hostname) {
     $hostname = "$user\@$hostname" if $user;
-    my $ssh_args = join " ", grep { $_ ne $instance_parts } @ARGV;
+    my $ssh_args = join " ", grep { $_ ne $instance_parts && $_ ne $private_ip } @ARGV;
     print STDERR "Connecting to $hostname [$tag_name]\n";
     print STDERR "\$ ssh $hostname $ssh_args\n" if $debug;
     exec("ssh $hostname $ssh_args");


### PR DESCRIPTION
A couple small changes to handle ec2 instance names with spaces and special characters, and prevent duplicating private ip in ssh command when using the --private option.
